### PR TITLE
add /status endpoint and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node ./tests/end_to_end_tests.js | node_modules/.bin/tap-spec",
-    "testing": "nodemon ./tests/end_to_end_tests.js | node_modules/.bin/tap-spec",
+    "test": "node ./tests/end_to_end_tests.js | node_modules/.bin/tap-difflet",
+    "testing": "nodemon ./tests/end_to_end_tests.js | node_modules/.bin/tap-difflet",
     "db": "mysql.server restart",
-    "sql": "mysql.server restart",
+    "dbconsole": "mysql -u root -D gentleman",
     "lint": "node_modules/.bin/eslint ./**/*.js --fix",
     "tail": "azure site log tail testsurpriseher"
   },
@@ -32,18 +32,17 @@
     "express": "^4.13.3",
     "moment": "^2.10.6",
     "mysql": "^2.8.0",
-    "nodemon": "^1.4.0",
     "twilio": "^2.3.0",
     "winston": "^1.0.1",
     "winston-bishop-slack": "^0.2.1",
     "winston-loggly": "^1.2.0"
   },
   "devDependencies": {
-    "chai": "^3.4.0",
+    "nodemon": "^1.4.0",
     "eslint": "^1.7.3",
     "sinon": "^1.17.2",
     "supertest": "^1.1.0",
-    "tap-spec": "^4.1.1",
+    "tap-difflet": "^0.4.0",
     "tape": "^4.2.2"
   },
   "eslintConfig": {

--- a/server/api/payments/payments.controller.js
+++ b/server/api/payments/payments.controller.js
@@ -47,10 +47,11 @@ exports.charge = (userBraintreeId, amount, callback) => {
 exports.generateToken = (req, res) => {
   global.Braintree.clientToken.generate({}, (error, response) => {
     if (error) {
-      const errorMessage = {message: "braintree failed to generate token", error}
+      const errorMessage = {message: "Braintree failed to generate token", error}
       log.error(errorMessage)
-      return res.send(httpStatus["Internal Server Error"].code, errorMessage)
+      return res.status(httpStatus["Internal Server Error"].code).send(errorMessage)
     } else {
+      res.set("Content-Type", "text/plain") // response is not html
       res.send(response.clientToken)
     }
   })

--- a/server/api/status.js
+++ b/server/api/status.js
@@ -1,0 +1,25 @@
+const log = require("../config/log.js")
+const httpStatus = require("../../httpStatuses.json")
+const express = require("express")
+const router = express.Router() // eslint-disable-line new-cap
+
+function queryDbStatus (callback) {
+  global.Db.query("SELECT * FROM users WHERE id = 0;", null, callback)
+}
+
+function getStatus (req, res) {
+  queryDbStatus(error => {
+    if (error) {
+      const errorMessage = {message: "queryDbStatus failed", error}
+      log.error(errorMessage)
+      res.sendStatus(httpStatus["Internal Server Error"].code)
+    } else {
+      log.debug("queryDbStatus was successful")
+      res.sendStatus(httpStatus.OK.code)
+    }
+  })
+}
+
+router.get("/", getStatus)
+
+module.exports = router

--- a/server/routes.js
+++ b/server/routes.js
@@ -2,6 +2,7 @@ const addressesRequestHandlers = require("./api/addresses/addresses.main")
 const usersRequestHandlers = require("./api/users/users.routes")
 const paymentsRequestHandlers = require("./api/payments/payments.routes")
 const transactionsRequestHandlers = require("./api/transactions/transactions.routes")
+const statusRequestHandler = require("./api/status")
 const viewsRequestHandlers = require("./public/views.routing")
 
 function routes (app) {
@@ -9,6 +10,7 @@ function routes (app) {
   app.use("/users", usersRequestHandlers)
   app.use("/payments", paymentsRequestHandlers)
   app.use("/transactions", transactionsRequestHandlers)
+  app.use("/status", statusRequestHandler)
   app.use("/", viewsRequestHandlers)
 }
 

--- a/tests/end_to_end_tests.js
+++ b/tests/end_to_end_tests.js
@@ -160,6 +160,49 @@ test("status fails when db is disconnected", t => {
   })
 })
 
+test("generates a braintree token for the client", t => {
+  const BraintreeClientTokenStub = sinon.stub(global.Braintree.clientToken, "generate", (_, callback) => { return callback(null, {clientToken: "aBc123=="}) })
+  t.plan(4) // eslint-disable-line no-magic-numbers
+  request(app)
+  .get("/payments/client_token")
+  .end((_, data) => {
+    t.equal(data.res.headers["content-type"], "text/plain; charset=utf-8", "it responds with plaintext")
+    t.equal(data.status, httpStatus.OK.code, "it responds with status 200 OK")
+    t.deepEqual(
+      BraintreeClientTokenStub.args.map(stripLastItem), // last arg is a callback
+      [[{}]],
+      "it generates a Braintree client token"
+    )
+    t.equal(data.text, "aBc123==", "it gives the client a Braintree token")
+    BraintreeClientTokenStub.restore()
+  })
+})
+
+test("fails to generate a braintree token for the client", t => {
+  const LogErrorStub = sinon.stub(global.Log, "error")
+  const BraintreeClientTokenStub = sinon.stub(global.Braintree.clientToken, "generate", (_, callback) => { return callback({authenticationError: "authenticationError"}) })
+  t.plan(5) // eslint-disable-line no-magic-numbers
+  request(app)
+  .get("/payments/client_token")
+  .end((_, data) => {
+    t.deepEqual(
+      BraintreeClientTokenStub.args.map(stripLastItem), // last arg is a callback
+      [[{}]],
+      "it attempts to generate a Braintree client token"
+    )
+    t.deepEqual(
+      LogErrorStub.args,
+      [[{error: {authenticationError: "authenticationError"}, message: "Braintree failed to generate token"}]],
+      "it logs the error"
+    )
+    t.equal(data.res.headers["content-type"], "application/json; charset=utf-8", "it responds with JSON")
+    t.equal(data.status, httpStatus["Internal Server Error"].code, "it responds with status 500 Internal Server Error")
+    t.deepEqual(data.body, {message: "Braintree failed to generate token", error: {authenticationError: "authenticationError"}}, "it responds with the error")
+    LogErrorStub.restore()
+    BraintreeClientTokenStub.restore()
+  })
+})
+
 test.skip("incomplete user texts with day and gift_code", t => {
   // receive Twilio webhook POST to transactions
   // expect log


### PR DESCRIPTION
@armandopmj this PR adds a /status endpoint that queries the DB with 
```SQL
SELECT * FROM users WHERE id = 0;
```
and two tests—one success and one error.
Please merge if it looks good!